### PR TITLE
Fix Ledger URL.

### DIFF
--- a/webserver/src/routes/home.html
+++ b/webserver/src/routes/home.html
@@ -186,7 +186,7 @@
         developers. <em>Mostly Haskell, Elm, TransactSQL and stuff I don’t remember.</em>
       </li>
       <li>
-        <a href="https://www.ledgerhq.com>">Ledger</a>, a crytowallet (cryptocurrency) company, where I meanly worked
+        <a href="https://www.ledger.com">Ledger</a>, a crytowallet (cryptocurrency) company, where I meanly worked
         on a low-level library. <em>Mostly C++, Typescript, Rust.</em>
       </li>
     </ul>


### PR DESCRIPTION
There was a rogue `>` in the Ledger anchor `href` which meant you could not click it. I also updated the URL while I was at it.